### PR TITLE
Remove product description justification

### DIFF
--- a/sass/components/_product.scss
+++ b/sass/components/_product.scss
@@ -119,7 +119,6 @@
 .nefo-view-list-report-desc {
   font-size: $view-list-desc-font-size;
   line-height: $view-list-desc-line-height;
-  text-align: justify;
 }
 
 // Unsere Themen


### PR DESCRIPTION
Ich bin gegen Blocksatz. Gerade bei Zeilen mit wenig Wörtern, kann es zu unschönen großen Lücken komment.
